### PR TITLE
feat: add github org-stats

### DIFF
--- a/data-sources/github/org-stats/README.md
+++ b/data-sources/github/org-stats/README.md
@@ -23,11 +23,5 @@ Collect statistics for the past 7 days:
 ```bash
 export GITHUB_TOKEN=<token>
 export ORG_STATS_TIMESTAMP=$(TZ=UTC date +%F_%T)_UTC
-org-stats --org nation3 --since 7d --top 100 --csv-path github-org-stats-7d_$ORG_STATS_TIMESTAMP.csv
-```
-
-To include PR reviews, add `--include-reviews`:
-
-```bash
 org-stats --org nation3 --since 7d --top 100 --include-reviews --csv-path github-org-stats-7d_$ORG_STATS_TIMESTAMP.csv
 ```

--- a/data-sources/github/org-stats/README.md
+++ b/data-sources/github/org-stats/README.md
@@ -1,0 +1,33 @@
+# org-stats
+
+Organization-wide GitHub statistics for Nation3.
+
+https://github.com/caarlos0/org-stats
+
+## Usage
+
+Install:
+
+```bash
+brew install caarlos0/tap/org-stats
+```
+
+Generate a GitHub access token:
+
+- Go to https://github.com/settings/tokens
+- Click "Generate new token"
+- Select the "repo" scope
+
+Collect statistics for the past 7 days:
+
+```bash
+export GITHUB_TOKEN=<token>
+export ORG_STATS_TIMESTAMP=$(TZ=UTC date +%F_%T)_UTC
+org-stats --org nation3 --since 7d --top 100 --csv-path github-org-stats-7d_$ORG_STATS_TIMESTAMP.csv
+```
+
+To include PR reviews, add `--include-reviews`:
+
+```bash
+org-stats --org nation3 --since 7d --top 100 --include-reviews --csv-path github-org-stats-7d_$ORG_STATS_TIMESTAMP.csv
+```

--- a/data-sources/github/org-stats/github-org-stats-7d_2022-11-11_03:34:51_UTC.csv
+++ b/data-sources/github/org-stats/github-org-stats-7d_2022-11-11_03:34:51_UTC.csv
@@ -1,6 +1,0 @@
-login,commits,lines-added,lines-removed
-aahna-ashina,47,37342,10154
-anastasiyabelyaeva,2,34,17
-credbot,1,198,0
-dependabot[bot],1,48,48
-xPi2,13,780,318

--- a/data-sources/github/org-stats/github-org-stats-7d_2022-11-11_03:34:51_UTC.csv
+++ b/data-sources/github/org-stats/github-org-stats-7d_2022-11-11_03:34:51_UTC.csv
@@ -1,0 +1,6 @@
+login,commits,lines-added,lines-removed
+aahna-ashina,47,37342,10154
+anastasiyabelyaeva,2,34,17
+credbot,1,198,0
+dependabot[bot],1,48,48
+xPi2,13,780,318

--- a/data-sources/github/org-stats/github-org-stats-7d_2022-11-14_09:05:52_UTC.csv
+++ b/data-sources/github/org-stats/github-org-stats-7d_2022-11-14_09:05:52_UTC.csv
@@ -1,0 +1,2 @@
+login,commits,lines-added,lines-removed,reviews
+aahna-ashina,6,6093,5728,4


### PR DESCRIPTION
For now, our main source of GitHub value creation is SourceCred.

However, we can consider including this dataset when we set up weekly GitHub Action PR generations for each Sunday.

To be included, the GitHub Nation3 Citizen's username would have to be linked with the ETH address in https://github.com/nation3/nationcred-datasets/blob/main/data-sources/github/github-usernames.csv