### PR TITLE
refactor: github workflow (#71)

### DIFF
--- a/.github/workflows/generate-datasets-weekly.yml
+++ b/.github/workflows/generate-datasets-weekly.yml
@@ -43,25 +43,17 @@ jobs:
         # Generate Historical Citizen Data CSVs 🧮
       - run: npm run generate-power
 
-      - name: Set Environment Variables for PR
-        id: pr_details
+      - name: Commit Changes
         run: |
-          echo "PULL_REQUEST_TITLE=Generated Citizens datasets for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
-          description="This PR was auto-generated on $(date +%Y-%m-%d)."
-          description="${description//'%'/'%25'}"
-          description="${description//$'\n'/'%0A'}"
-          description="${description//$'\r'/'%0D'}"
-          echo "::set-output name=pr_body::$description"
-
-      - name: Create commit and PR for the changes
-        id: pr
-        uses: peter-evans/create-pull-request@v4.2.0
-        with:
-          branch: generated-datasets
-          branch-suffix: timestamp
-          commit-message: generate citizens datasets
-          title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ steps.pr_details.outputs.pr_body }}
+          git config user.name 'NationCred bot'
+          git config user.email 'nationcred.bot@nation3.org'
+          git fetch
+          git pull
+          git add output/*
+          git commit --allow-empty -m 'generate citizens datasets'
+      
+      - name: Push Changes
+        run: git push
 
   sourcecred:
     needs: citizens
@@ -85,25 +77,17 @@ jobs:
       - run: npm run build
       - run: npm run generate
 
-      - name: Set Environment Variables for PR
-        id: pr_details
+      - name: Commit Changes
         run: |
-          echo "PULL_REQUEST_TITLE=Generated SourceCred datasets for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
-          description="This PR was auto-generated on $(date +%Y-%m-%d)."
-          description="${description//'%'/'%25'}"
-          description="${description//$'\n'/'%0A'}"
-          description="${description//$'\r'/'%0D'}"
-          echo "::set-output name=pr_body::$description"
-
-      - name: Create commit and PR for the changes
-        id: pr
-        uses: peter-evans/create-pull-request@v4.2.0
-        with:
-          branch: generated-datasets
-          branch-suffix: timestamp
-          commit-message: generate sourcecred datasets
-          title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ steps.pr_details.outputs.pr_body }}
+          git config user.name 'NationCred bot'
+          git config user.email 'nationcred.bot@nation3.org'
+          git fetch
+          git pull
+          git add output/*
+          git commit --allow-empty -m 'generate sourcecred datasets'
+      
+      - name: Push Changes
+        run: git push
 
   dework:
     needs: citizens
@@ -127,25 +111,17 @@ jobs:
       - run: npm run build
       - run: npm run generate
 
-      - name: Set Environment Variables for PR
-        id: pr_details
+      - name: Commit Changes
         run: |
-          echo "PULL_REQUEST_TITLE=Generated Dework datasets for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
-          description="This PR was auto-generated on $(date +%Y-%m-%d)."
-          description="${description//'%'/'%25'}"
-          description="${description//$'\n'/'%0A'}"
-          description="${description//$'\r'/'%0D'}"
-          echo "::set-output name=pr_body::$description"
-
-      - name: Create commit and PR for the changes
-        id: pr
-        uses: peter-evans/create-pull-request@v4.2.0
-        with:
-          branch: generated-datasets
-          branch-suffix: timestamp
-          commit-message: generate dework datasets
-          title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ steps.pr_details.outputs.pr_body }}
+          git config user.name 'NationCred bot'
+          git config user.email 'nationcred.bot@nation3.org'
+          git fetch
+          git pull
+          git add output/*
+          git commit --allow-empty -m 'generate dework datasets'
+      
+      - name: Push Changes
+        run: git push
 
   karma:
     needs: citizens
@@ -169,25 +145,17 @@ jobs:
       - run: npm run build
       - run: npm run generate
 
-      - name: Set Environment Variables for PR
-        id: pr_details
+      - name: Commit Changes
         run: |
-          echo "PULL_REQUEST_TITLE=Generated Karma datasets for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
-          description="This PR was auto-generated on $(date +%Y-%m-%d)."
-          description="${description//'%'/'%25'}"
-          description="${description//$'\n'/'%0A'}"
-          description="${description//$'\r'/'%0D'}"
-          echo "::set-output name=pr_body::$description"
-
-      - name: Create commit and PR for the changes
-        id: pr
-        uses: peter-evans/create-pull-request@v4.2.0
-        with:
-          branch: generated-datasets
-          branch-suffix: timestamp
-          commit-message: generate karma datasets
-          title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ steps.pr_details.outputs.pr_body }}
+          git config user.name 'NationCred bot'
+          git config user.email 'nationcred.bot@nation3.org'
+          git fetch
+          git pull
+          git add output/*
+          git commit --allow-empty -m 'generate karma datasets'
+      
+      - name: Push Changes
+        run: git push
 
   nationcred:
     needs: sourcecred
@@ -211,22 +179,14 @@ jobs:
       - run: npm run build
       - run: npm run generate
 
-      - name: Set Environment Variables for PR
-        id: pr_details
+      - name: Commit Changes
         run: |
-          echo "PULL_REQUEST_TITLE=Generated NationCred datasets for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
-          description="This PR was auto-generated on $(date +%Y-%m-%d)."
-          description="${description//'%'/'%25'}"
-          description="${description//$'\n'/'%0A'}"
-          description="${description//$'\r'/'%0D'}"
-          echo "::set-output name=pr_body::$description"
-
-      - name: Create commit and PR for the changes
-        id: pr
-        uses: peter-evans/create-pull-request@v4.2.0
-        with:
-          branch: generated-datasets
-          branch-suffix: timestamp
-          commit-message: generate nationcred datasets
-          title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ steps.pr_details.outputs.pr_body }}
+          git config user.name 'NationCred bot'
+          git config user.email 'nationcred.bot@nation3.org'
+          git fetch
+          git pull
+          git add output/*
+          git commit --allow-empty -m 'generate nationcred datasets'
+      
+      - name: Push Changes
+        run: git push


### PR DESCRIPTION
After this code change, the weekly cron jobs will commit to `main` instead of generating a PR to be merged.

## Dework Task

https://app.dework.xyz/nation3/nationcred-p?taskId=ca582fd0-5138-4dd4-9347-7b55ea29b483

## Related GitHub Issue

closes #71

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

- [x] Status checks pass
- [x] Works on Mainnet
- [x] Tested workflow with trigger branch name:  https://github.com/nation3/nationcred-datasets/actions/runs/3805085179

> <img width="915" alt="Screenshot 2022-12-30 at 2 02 05 PM" src="https://user-images.githubusercontent.com/95955389/210039575-f83bc64c-e8fe-4dec-ace1-38348d0d8d83.png">

Reviewed the commits:  https://github.com/nation3/nationcred-datasets/commits/generate-datasets-trigger-71

> <img width="369" alt="Screenshot 2022-12-30 at 2 00 13 PM" src="https://user-images.githubusercontent.com/95955389/210039542-09f3d0a4-83f2-418d-bc88-5f011b999d7a.png">


## Are There Admin Tasks?

<!--- Please include any related admin tasks, like adding/changing environment variables in Vercel. -->
