### PR TITLE
chore: adjust time estimation

### DIFF
--- a/nationcred/src/generate-datasets.ts
+++ b/nationcred/src/generate-datasets.ts
@@ -73,7 +73,7 @@ async function loadNationCredData() {
         }
       })
       console.info('sourceCredScore:', sourceCredScore)
-      const sourceCredHours: number = sourceCredScore / 2.5
+      const sourceCredHours: number = sourceCredScore / 3.125
       console.info('sourceCredHours:', sourceCredHours)
 
       valueCreationHours += sourceCredHours


### PR DESCRIPTION
When we manually compared hours tracked in Dework and hours estimated by NationCred, we learned that the real number was 80% of the estimated number.

So adjusting 2.5 to 2.5/0.8 = 3.125

## Related GitHub Issue

<!--- Please link to the GitHub issue here. -->

https://github.com/nation3/nationcred-datasets/issues/54

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

- [ ] Status checks pass
- [ ] Works on Goerli
- [ ] Works on Mainnet

## Are There Admin Tasks?

<!--- Please include any related admin tasks, like adding/changing environment variables in Vercel. -->
